### PR TITLE
Add ci and conda

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,23 @@
+[bumpversion]
+current_version = 0.0.1dev0
+commit = False
+tag = False
+tag_name = {new_version}
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<build>\d+))?
+serialize = 
+	{major}.{minor}.{patch}{release}{build}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+first_value = dev
+optional_value = release
+values = 
+	dev
+	release
+
+[bumpversion:part:build]
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:ndstructs/__init__.py]
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+python:
+  - 3.7
+
+before_install:
+  - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=$HOME/miniconda3/bin:$PATH
+  - conda update --yes -q conda -c conda-forge
+  - conda config --set always_yes true
+  - conda config --set anaconda_upload no
+
+install:
+  - conda install -q conda-build pip anaconda-client
+  - conda build conda-recipe
+  - conda create -n test-env --use-local ndstructs pytest
+
+script:
+  - source activate test-env
+  - pytest .

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,10 @@ install:
 script:
   - source activate test-env
   - pytest .
+
+deploy:
+  - provider: script
+    script: anaconda -t $CONDA_UPLOAD_TOKEN upload $HOME/miniconda3/conda-bld/**/ndstructs-*.tar.bz2 --label staging
+    on:
+      tags: true
+    skip_cleanup: true

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,34 @@
+{% set data = load_setup_py_data() %}
+
+package:
+  name: ndstructs
+  version: {{ data['version'] }}
+
+source:
+  path: ..
+
+build:
+  noarch: python
+  script:
+        - python -m pip install --no-deps --ignore-installed .
+requirements:
+  build:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+    # dependencies are defined in setup.py
+    {% for dep in data['install_requires'] %}
+    - {{ dep.lower() }}
+    {% endfor %}
+
+test:
+  imports:
+    - ndstructs
+    - ndstructs.utils
+  source_files:
+    - tests
+  requires:
+    - pytest
+  commands:
+    - pytest .

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,50 @@
+# Development
+
+## Create a development environment
+
+```bash
+conda env create --file dev/environment-dev.py
+```
+
+This will create an environment with the name `ndstructs-dev`, that can be activated with `conda activate ndstructs-dev`.
+
+Install the `pre-commit` hook after activating your development environment with
+
+```bash
+pre-commit install
+```
+
+Before committing black will be run automatically on your change-set.
+
+## Automatic versioning with bumpversion
+
+The following versioning scheme is implemented `<major>.<minor>.<patch><release-type><build>`. `major`, `minor`, and `patch` shouldn't need more introduction.
+The only _special_ thing here is the `release-type` with its `build`. `release-type` will take the value of `dev` as a default and the `build` is a simple counter.
+
+```
+1.2.3dev4
+^ ^ ^ ^ ^     command                 result
+| | | | |
+| | | | +--+ `bumpversion build`   -> 1.2.3dev5
+| | | |
+| | | +----+ `bumpversion release` -> 1.2.3
+| | |
+| | +------+ `bumpversion patch`   -> 1.2.4dev0
+| |
+| +--------+ `bumpversion minor`   -> 1.3.0dev0
+|
++----------+ `bumpversion major`   -> 2.0.0dev0
+
+```
+
+## Dependency management
+
+There are two different types of dependencies:
+
+1) Package dependencies for deployment: These dependencies should be added to your project's `setup.py` under the requirements section. These packages are automatically added to the conda recipe in `conda-recipe/meta.yaml`. 
+2) Development dependencies: All packages that are needed for development, should be added to your package's `dev/environment-dev.yaml`.
+
+## Black style checking / pre-commit
+
+This repo comes with a `.pre-commit-config.yaml` that allows for convenient automatic use of the [black](https://github.com/ambv/black) code formatter.
+Black will be run before every commit. In case reformatting is necessary, the commit action is aborted. Reformatted changes have to be added and the commit has to be triggered again.

--- a/dev/environment-dev.yaml
+++ b/dev/environment-dev.yaml
@@ -1,0 +1,12 @@
+name: ndstructs-dev
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - black
+  - bumpversion
+  - numpy
+  - pillow
+  - pre_commit
+  - pytest
+  - python >=3.6

--- a/ndstructs/__init__.py
+++ b/ndstructs/__init__.py
@@ -1,3 +1,5 @@
 from .array5D import Array5D
 from .array5D import Image, ScalarImage, LinearData, ScalarData, ScalarLine, StaticLine
 from .point5D import Point5D, Shape5D, Slice5D
+
+__version__ = "0.0.1dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 120
+target-version = ['py37']

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(
+    name="ndstructs",
+    version="0.0.1",
+    author="Tomaz Vieira",
+    author_email="team@ilastik.org",
+    license="MIT",
+    description="Short description",
+    packages=["ndstructs", "ndstructs.utils"],
+    install_requires=["numpy", "pillow"],
+)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="ndstructs",
-    version="0.0.1",
+    version="0.0.1dev0",
     author="Tomaz Vieira",
     author_email="team@ilastik.org",
     license="MIT",


### PR DESCRIPTION
Summary:

* added conda-recipe
* added travis ci
* added pre-commit hook with black
  * would be great if you could run black over the repo ones this is merged.
* added bumpversion
* added development environment for conda
* added autodeploy to ilastik-forge for every pushed tag. Package is labeled "staging" and has to be transferred to the main label manually. https://anaconda.org/ilastik-forge/ndstructs


Todos:

* [x] automatic deployment to ilastik-forge

