### PR TITLE
Adds DataSource and some tests

### DIFF
--- a/ndstructs/datasource/DataSource.py
+++ b/ndstructs/datasource/DataSource.py
@@ -1,0 +1,109 @@
+from abc import ABC, abstractmethod, abstractproperty
+from functools import lru_cache
+from typing import List, Iterator
+from numbers import Number
+
+import numpy as np
+
+import enum
+from enum import IntEnum
+
+from ndstructs import Array5D, Point5D, Shape5D, Slice5D
+from ndstructs.utils import JsonSerializable
+
+
+@enum.unique
+class AddressMode(IntEnum):
+    BLACK = 0
+    MIRROR = enum.auto()
+    WRAP = enum.auto()
+
+
+class DataSource(Slice5D):
+    @classmethod
+    @abstractmethod
+    def get_full_shape(cls, url: str) -> Shape5D:
+        pass
+
+    def __init__(self, url: str, *, t=slice(None), c=slice(None), x=slice(None), y=slice(None), z=slice(None)):
+        self.url = url
+        self.full_shape = self.get_full_shape(url)
+        self.roi = Slice5D(t=t, c=c, x=x, y=y, z=z).defined_with(self.full_shape)
+        super().__init__(**self.roi.to_dict())
+
+    @classmethod
+    def from_json_data(cls, data: dict):
+        start = Point5D.from_json_data(data["start"]) if "start" in data else Point5D.zero()
+        stop = Point5D.from_json_data(data["stop"]) if "stop" in data else Point5D.inf()
+        slices = cls.make_slices(start, stop)
+        return cls(data["url"], **slices)
+
+    @property
+    def json_data(self):
+        return {**super().json_data, "url": self.url}
+
+    def __repr__(self):
+        return super().__repr__() + f"({self.url.split('/')[-1]})"
+
+    def rebuild(self, *, t=slice(None), c=slice(None), x=slice(None), y=slice(None), z=slice(None)) -> "DataSource":
+        return self.__class__(self.url, t=t, c=c, x=x, y=y, z=z)
+
+    def __hash__(self):
+        return hash((self.url, self.roi))
+
+    def __eq__(self, other):
+        if not super().__eq__(other):
+            return False
+        if isinstance(other, self.__class__):
+            return self.url == other.url
+        return True
+
+    def full(self) -> "DataSource":
+        return self.__class__(self.url, **Slice5D.all().to_dict())
+
+    def resize(self, slc: Slice5D):
+        return self.__class__(self.url, **slc.to_dict())
+
+    @abstractproperty
+    def dtype(self):
+        pass
+
+    @abstractmethod
+    def get(self) -> Array5D:
+        pass
+
+    def contains(self, slc: Slice5D) -> bool:
+        return self.roi.contains(slc.defined_with(self.full_shape))
+
+    @abstractproperty
+    def tile_shape(self):
+        """A sensible tile shape. Override this with your data chunk size"""
+        pass
+
+    def clamped(self, slc: Slice5D = None) -> "DataSource":
+        return super().clamped(slc or self.full())
+
+    @abstractmethod
+    def _allocate(self, fill_value: Number) -> Array5D:
+        pass
+
+    def retrieve(self, address_mode: AddressMode = AddressMode.BLACK) -> Array5D:
+        # FIXME: Remove address_mode or implement all variations and make feature extractors
+        # use te correct one
+        out = self._allocate(fill_value=0)
+        data_roi = self.clamped()
+        for tile in data_roi.get_tiles():
+            tile_data = tile.get()
+            out.set(tile_data, autocrop=True)
+        return out  # TODO: make slice read-only
+
+    def get_tiles(self, tile_shape: Shape5D = None):
+        for tile in super().get_tiles(tile_shape or self.tile_shape):
+            clamped_tile = tile.clamped(self.full())
+            yield self.__class__(self.url, **clamped_tile.to_dict())
+
+    def __getstate__(self):
+        return self.json_data
+
+    def __setstate__(self, data: dict):
+        self.__init__(data["url"], Slice5D.from_json(data["roi"]))

--- a/ndstructs/datasource/DataSource.py
+++ b/ndstructs/datasource/DataSource.py
@@ -10,6 +10,7 @@ from enum import IntEnum
 
 from ndstructs import Array5D, Point5D, Shape5D, Slice5D
 from ndstructs.utils import JsonSerializable
+from .UnsupportedUrlException import UnsupportedUrlException
 
 
 @enum.unique
@@ -24,6 +25,17 @@ class DataSource(Slice5D):
     @abstractmethod
     def get_full_shape(cls, url: str) -> Shape5D:
         pass
+
+    def __new__(cls, url: str, *, t=slice(None), c=slice(None), x=slice(None), y=slice(None), z=slice(None)):
+        if cls is not DataSource:
+            return super().__new__(cls)
+        for klass in cls.__subclasses__():
+            try:
+                return klass(url, t=t, c=c, x=x, y=y, z=z)
+            except UnsupportedUrlException as e:
+                pass
+        else:
+            raise UnsupportedUrlException(url)
 
     def __init__(self, url: str, *, t=slice(None), c=slice(None), x=slice(None), y=slice(None), z=slice(None)):
         self.url = url

--- a/ndstructs/datasource/PilDataSource.py
+++ b/ndstructs/datasource/PilDataSource.py
@@ -1,0 +1,36 @@
+import numpy as np
+from PIL import Image as PilImage
+
+from ndstructs.datasource import DataSource
+from ndstructs import Array5D, Image, Point5D, Shape5D, Slice5D
+import functools
+
+
+class PilDataSource(DataSource):
+    """A naive implementation o DataSource that can read images using PIL"""
+
+    @classmethod
+    @functools.lru_cache()
+    def get_full_shape(cls, url: str) -> Shape5D:
+        img = PilImage.open(url)
+        return Shape5D(x=img.width, y=img.height, c=len(img.getbands()))
+
+    def _allocate(self, fill_value: int) -> Image:
+        return Image.allocate(self, dtype=self.dtype, value=fill_value)
+
+    @property
+    def tile_shape(self):
+        return Shape5D(x=1024, y=1024, c=self.shape.c)
+
+    def __init__(self, url: str, *, t=slice(None), c=slice(None), x=slice(None), y=slice(None), z=slice(None)):
+        raw_data = np.asarray(PilImage.open(url))
+        axiskeys = "yxc"[: len(raw_data.shape)]
+        self._data = Image(raw_data, axiskeys=axiskeys)
+        super().__init__(url, t=t, c=c, x=x, y=y, z=z)
+
+    @property
+    def dtype(self):
+        return self._data.dtype
+
+    def get(self) -> Image:
+        return self._data.cut(self.roi, copy=True)

--- a/ndstructs/datasource/UnsupportedUrlException.py
+++ b/ndstructs/datasource/UnsupportedUrlException.py
@@ -1,0 +1,2 @@
+class UnsupportedUrlException(Exception):
+    pass

--- a/ndstructs/datasource/__init__.py
+++ b/ndstructs/datasource/__init__.py
@@ -1,0 +1,2 @@
+from .DataSource import DataSource
+from .PilDataSource import PilDataSource

--- a/ndstructs/datasource/__init__.py
+++ b/ndstructs/datasource/__init__.py
@@ -1,2 +1,3 @@
 from .DataSource import DataSource
 from .PilDataSource import PilDataSource
+from .UnsupportedUrlException import UnsupportedUrlException

--- a/ndstructs/utils/JsonSerializable.py
+++ b/ndstructs/utils/JsonSerializable.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 import json
 import inspect
+import re
 
 
 def get_constructor_params(klass):
@@ -15,10 +16,10 @@ def get_constructor_params(klass):
 
 
 def hint_to_wrapper(type_hint):
-    if str(type_hint).find("List[") >= 0:
+    if re.search("^(typing\.)?(List|Iterable|Tuple)\[", str(type_hint)):
         item_type = type_hint.__args__[0]
         return lambda value: [from_json_data(item_type, v) for v in value]
-    raise NotImplemented(f"Don't know how to unwrap {type_hint}")
+    raise NotImplementedError(f"Don't know how to unwrap {type_hint}")
 
 
 def from_json_data(cls, data):

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
     author_email="team@ilastik.org",
     license="MIT",
     description="Short description",
-    packages=["ndstructs", "ndstructs.utils"],
+    packages=["ndstructs", "ndstructs.utils", "ndstructs.datasource"],
     install_requires=["numpy", "pillow"],
 )

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -1,0 +1,83 @@
+import pytest
+import os
+import tempfile
+import numpy as np
+from ndstructs import Shape5D, Slice5D
+from ndstructs.datasource import DataSource, PilDataSource
+from PIL import Image as PilImage
+
+# fmt: off
+raw = np.asarray([
+    [1,  2,  3,  4,  5],
+    [6,  7,  8,  9,  10],
+    [11, 12, 13, 14, 15],
+    [16, 17, 18, 19, 20],
+]).astype(np.uint8)
+
+raw_0_2x0_2y = np.asarray([
+    [1,2],
+    [6,7]
+])
+
+raw_0_2x2_4y = np.asarray([
+    [11,12],
+    [16,17]
+])
+
+raw_2_4x0_2y = np.asarray([
+    [3,4],
+    [8,9]
+])
+
+raw_2_4x2_4y = expected_raw = np.asarray([
+    [13,14],
+    [18,19]
+])
+
+raw_4_5x0_2y = np.asarray([
+    [5],
+    [10]
+])
+
+raw_4_5x2_4y = np.asarray([
+    [15],
+    [20]
+])
+# fmt: on
+
+
+@pytest.fixture
+def png_image() -> str:
+    pil_image = PilImage.fromarray(raw)
+    _, png_path = tempfile.mkstemp()
+    with open(png_path, "wb") as png_file:
+        pil_image.save(png_file, "png")
+    yield png_path
+    os.remove(png_path)
+
+
+def tile_equals(tile: DataSource, axiskeys: str, raw: np.ndarray):
+    return (tile.retrieve().raw(axiskeys) == raw).all()
+
+
+def test_pil_datasource_tiles(png_image: str):
+    ds = PilDataSource(png_image)
+    num_checked_tiles = 0
+    for tile in ds.get_tiles(Shape5D(x=2, y=2)):
+        if tile == Slice5D.zero(x=slice(0, 2), y=slice(0, 2)):
+            expected_raw = raw_0_2x0_2y
+        elif tile == Slice5D.zero(x=slice(0, 2), y=slice(2, 4)):
+            expected_raw = raw_0_2x2_4y
+        elif tile == Slice5D.zero(x=slice(2, 4), y=slice(0, 2)):
+            expected_raw = raw_2_4x0_2y
+        elif tile == Slice5D.zero(x=slice(2, 4), y=slice(2, 4)):
+            expected_raw = raw_2_4x2_4y
+        elif tile == Slice5D.zero(x=slice(4, 5), y=slice(0, 2)):
+            expected_raw = raw_4_5x0_2y
+        elif tile == Slice5D.zero(x=slice(4, 5), y=slice(2, 4)):
+            expected_raw = raw_4_5x2_4y
+        else:
+            raise Exception(f"Unexpected tile {tile}")
+        assert (tile.retrieve().raw("yx") == expected_raw).all()
+        num_checked_tiles += 1
+    assert num_checked_tiles == 6


### PR DESCRIPTION
Adds the `DataSource` class, which is essentially a `Slice5D` backed by some data somewhere (usually a file).

This is currently the source of lazyness in ndstructs, as you can manipulate a `DataSource`'s shape, split it into tiles, expand it to cover a halo, and then call `retrieve` to get back some real data in a `Array5D`.

This has the drawback that tiles are made explicit to the client, as opposed to just having a big lazy array, but it also incentivizes the use of the native tile size (e.g. that which is used to store it) when processing big data, and also makes it easier to make several independent requests to several potential servers in a cluster, each processing an independent tile.

This PR also comes with `PilDataSource`, which is the most naive implementation of `DataSource`; Since `PIL` can't read pieces of an image without loading it all into memory, it just serves to ilustrate DataSource expected behavior and to make tests with small images.

Each different file type should be implemented in its own `DataSource` child class.