### PR TITLE
Removed dev methods/members

### DIFF
--- a/ndstructs/array5D.py
+++ b/ndstructs/array5D.py
@@ -2,9 +2,7 @@ import itertools
 from typing import Iterator, List, Tuple
 import numpy as np
 import io
-import os
 from PIL import Image as PilImage
-import uuid
 
 from .point5D import Point5D, Slice5D, Shape5D
 from ndstructs.utils import JsonSerializable
@@ -81,9 +79,6 @@ class RawShape:
 class Array5D(JsonSerializable):
     """A wrapper around np.ndarray with labeled axes. Enforces 5D, even if some
     dimensions are of size 1. Sliceable with Slice5D's"""
-
-    DISPLAY_IMAGE_PREFIX = "/tmp/junk_test_image_"
-    os.system(f"rm -vf {DISPLAY_IMAGE_PREFIX}*")
 
     def __init__(self, arr: np.ndarray, axiskeys: str, location: Point5D = Point5D.zero()):
         assert len(arr.shape) == len(axiskeys)
@@ -279,21 +274,6 @@ class Array5D(JsonSerializable):
     def as_uint8(self, normalized=True):
         multi = 255 if normalized else 1
         return Array5D((self._data * multi).astype(np.uint8), axiskeys=self.axiskeys)
-
-    def _show(self):
-        path = f"{self.DISPLAY_IMAGE_PREFIX}_{uuid.uuid4()}.png"
-        self.as_pil_images()[0].save(path)
-        os.system(f"gimp {path}")
-
-    def show_images(self):
-        for img_idx, img in enumerate(self.images()):
-            for channel_idx, channel in enumerate(img.channels()):
-                channel._show()
-
-    def show_channels(self):
-        for img in self.images():
-            for channel in img.channels():
-                channel._show()
 
 
 class StaticData(Array5D):


### PR DESCRIPTION
When making the 1.3.3post2 release, I got an error out of nowhere claiming that `rm` was not available on windows. Could trace it back to this very developy code that this pr removes.

Removed all methods that refer to non-standard things,
or rely on third party
apps (gimp). These should not go into a release.

the `os.system` call furthermore produced and error on windows.